### PR TITLE
fix: edge case in Sum()

### DIFF
--- a/money.go
+++ b/money.go
@@ -108,7 +108,7 @@ func Sum(l, r pb.Money) (pb.Money, error) {
 	units := l.GetUnits() + r.GetUnits()
 	nanos := l.GetNanos() + r.GetNanos()
 
-	if (units == 0 && nanos == 0) || (units > 0 && nanos >= 0) || (units < 0 && nanos <= 0) {
+	if (units >= 0 && nanos >= 0) || (units <= 0 && nanos <= 0) {
 		// same sign <units, nanos>
 		units += int64(nanos / nanosMod)
 		nanos = nanos % nanosMod

--- a/money_test.go
+++ b/money_test.go
@@ -229,6 +229,8 @@ func TestSum(t *testing.T) {
 		{"mixed (larger negative, with borrow)", args{mm(-11, -100000000), mm(2, 9000000 /*.09*/)}, mm(-9, -91000000 /*.091*/), nil},
 		{"0+negative", args{mm(0, 0), mm(-2, -100000000)}, mm(-2, -100000000), nil},
 		{"negative+0", args{mm(-2, -100000000), mm(0, 0)}, mm(-2, -100000000), nil},
+		{"0.61+0", args{mm(0, 610000000), mm(0, 0)}, mm(0, 610000000), nil},
+		{"-0.61+0", args{mm(0, -610000000), mm(0, 0)}, mm(0, -610000000), nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
It seems like there has been an oversight in the `Sum()` function.
There is no validation after a sum to make sure that the result is still valid. Therefore, this bug might have silently impacted the users of this lib by producing wrong values.